### PR TITLE
Explicitly set output dir permissions to 0755

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 rest/*
 *.exe
 gql/*
+api-generator

--- a/utils/saveStringToFile.go
+++ b/utils/saveStringToFile.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +13,7 @@ func CreateFilePath(filePath string) error {
 	for _, part := range pathParts {
 		pathBuilder = pathBuilder + part + "/"
 		if _, err := os.Stat(pathBuilder); os.IsNotExist(err) {
-			if err := os.Mkdir(pathBuilder, fs.ModeAppend|0755); err != nil {
+			if err := os.Mkdir(pathBuilder, 0755); err != nil {
 				return err
 			}
 		}

--- a/utils/saveStringToFile.go
+++ b/utils/saveStringToFile.go
@@ -14,7 +14,7 @@ func CreateFilePath(filePath string) error {
 	for _, part := range pathParts {
 		pathBuilder = pathBuilder + part + "/"
 		if _, err := os.Stat(pathBuilder); os.IsNotExist(err) {
-			if err := os.Mkdir(pathBuilder, fs.ModeAppend); err != nil {
+			if err := os.Mkdir(pathBuilder, fs.ModeAppend|0755); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
##  Description

On mac (*nix?) the output dir was getting created without any permissions, so the subsequent writes were failing. This change makes makes the output dir 0755 so the app can write to it.

I went back and forth in my head on whether or not to keep the `fs.ModeAppend` bits here. Let me know if that should be retained.